### PR TITLE
Fix cookies was not saved because of HttpOnly flag

### DIFF
--- a/pages/Login.jsx
+++ b/pages/Login.jsx
@@ -38,7 +38,7 @@ function Login() {
       } else {
         let {_id, username, token } = res
         
-        const cookieOptions = { maxAge: 2592000, path: '/', secure: process.env.NODE_ENV === 'production', httpOnly: true }
+        const cookieOptions = { maxAge: 2592000, path: '/', secure: process.env.NODE_ENV === 'production' }
         document.cookie = `token=${token}; ${Object.keys(cookieOptions).map(key => `${key}=${cookieOptions[key]}`).join('; ')}`;
 
         setUser({ id: _id, username, token }); 

--- a/pages/register.jsx
+++ b/pages/register.jsx
@@ -46,7 +46,7 @@ const Register = () => {
     register(data).then((res) => {
       let {_id, token } = res
 
-      const cookieOptions = { maxAge: 2592000, path: '/', secure: process.env.NODE_ENV === 'production', httpOnly: true }
+      const cookieOptions = { maxAge: 2592000, path: '/', secure: process.env.NODE_ENV === 'production' }
       document.cookie = `token=${token}; ${Object.keys(cookieOptions).map(key => `${key}=${cookieOptions[key]}`).join('; ')}`;
 
       setUser({ id: _id, token });


### PR DESCRIPTION
This pull request includes changes to the `Login` and `Register` components to modify the cookie options. The `httpOnly` attribute has been removed from the cookie options in both components.

Changes to cookie options:

* [`pages/Login.jsx`](diffhunk://#diff-0e34184b0cc3e928758d959cf29134e60b7b5dd1cbb8674e986ec4403242773cL41-R41): Removed `httpOnly` attribute from the cookie options in the `Login` function.
* [`pages/register.jsx`](diffhunk://#diff-f17820512e7bc0080968021a392d0019b06e17a6d31349b1a3785dd82c4bd9d5L49-R49): Removed `httpOnly` attribute from the cookie options in the `Register` function.