### PR TITLE
Fix post view crashing because of fetchProfileById()

### DIFF
--- a/pages/post/[id].jsx
+++ b/pages/post/[id].jsx
@@ -8,7 +8,7 @@ import { faEllipsis, faHeart as faFilledHeart, faComment } from '@fortawesome/fr
 import { faHeart as faEmptyHeart } from '@fortawesome/free-regular-svg-icons';
 import Image from 'next/image';
 import Link from 'next/link';
-import { fetchFeed, likePost, removeLike } from '@/utils/api';
+import { fetchFeed, likePost, removeLike, fetchProfileById } from '@/utils/api';
 import { UserContext } from '../_app';
 
 function PostView({ endpointPost = {}, jwt = '' }) {


### PR DESCRIPTION
This pull request includes an update to the import statements in the `pages/post/[id].jsx` file to include the `fetchProfileById` function from the `@/utils/api` module.

Changes to import statements:

* `pages/post/[id].jsx`: Added `fetchProfileById` to the list of imported functions from `@/utils/api`. ([pages/post/[id].jsxL11-R11](diffhunk://#diff-2638bca47dcdf523214047befe929becf26e0c9367fca0031ec36df95480eae0L11-R11))