### PR TITLE
Fix post's user redirect was wrong

### DIFF
--- a/pages/post/[id].jsx
+++ b/pages/post/[id].jsx
@@ -40,7 +40,7 @@ function PostView({ endpointPost = {}, jwt = '' }) {
           <div className={styles.post_move}>
             <div className={styles.post}>
                 <div className={styles.post__top}>
-                    <Link href={`/profile/${post.user.username}`}>
+                    <Link href={`/${post.user.username}`}>
                         <Image 
                             className={styles.post__top__user__img} 
                             src={post.user.profilePicture ? post.user.profilePicture : "/default-profile.webp"} 


### PR DESCRIPTION
This pull request includes a minor change to the `pages/post/[id].jsx` file. The change updates the URL structure for user profile links.

* `pages/post/[id].jsx`: Changed the user profile link from `/profile/${post.user.username}` to `/${post.user.username}`. ([pages/post/[id].jsxL43-R43](diffhunk://#diff-2638bca47dcdf523214047befe929becf26e0c9367fca0031ec36df95480eae0L43-R43))