### PR TITLE
Fixed /register not saving username in Local Storage

### DIFF
--- a/pages/register.jsx
+++ b/pages/register.jsx
@@ -42,12 +42,12 @@ const Register = () => {
     let username = e.target.username.value;
 
     register(email, password, username).then((res) => {
-      let {_id, token } = res
+      let {_id, username, token } = res
 
       const cookieOptions = { maxAge: 2592000, path: '/', secure: process.env.NODE_ENV === 'production' }
       document.cookie = `token=${token}; ${Object.keys(cookieOptions).map(key => `${key}=${cookieOptions[key]}`).join('; ')}`;
 
-      setUser({ id: _id, token });
+      setUser({ id: _id, username, token });
       window.location.href = '/';
     }).catch((err) => {
       setError(err.response.data.message);


### PR DESCRIPTION
This pull request includes a small but important change to the `pages/register.jsx` file. The change ensures that the `username` is also stored in the user state after registration.

* [`pages/register.jsx`](diffhunk://#diff-f17820512e7bc0080968021a392d0019b06e17a6d31349b1a3785dd82c4bd9d5L45-R50): Updated the `register` function to include the `username` in the response and store it in the user state.